### PR TITLE
Feature/add coralogix scaler

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -24,7 +24,7 @@ jobs:
       - run: go version
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v7
+        uses: tj-actions/branch-names@v8
       - uses: fossas/fossa-action@main
         name: Scanning with FOSSA
         with:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -182,7 +182,7 @@ jobs:
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
 
       - name: React to comment with success
-        uses: dkershner6/reaction-action@v1
+        uses: dkershner6/reaction-action@v2
         if: steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ jobs:
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
       - name: React to comment with failure
-        uses: dkershner6/reaction-action@v1
+        uses: dkershner6/reaction-action@v2
         if: steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -22,16 +22,16 @@ jobs:
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: go
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: +security-and-quality
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:go"

--- a/.github/workflows/static-analysis-semgrep.yml
+++ b/.github/workflows/static-analysis-semgrep.yml
@@ -35,7 +35,7 @@ jobs:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif
         if: ${{ github.event.number == '' && !cancelled() }}

--- a/.github/workflows/template-trivy-scan.yml
+++ b/.github/workflows/template-trivy-scan.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.16.0
         with:
           scan-type: ${{ inputs.scan-type }}
           image-ref: ${{ inputs.image-ref }}

--- a/.github/workflows/template-trivy-scan.yml
+++ b/.github/workflows/template-trivy-scan.yml
@@ -51,7 +51,7 @@ jobs:
           trivy-config: trivy.yml
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: ${{ inputs.publish }}
         with:
           sarif_file: ${{ inputs.output }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ## Unreleased
 
+- **General:** Introduce new Coralogix Scaler [#ISSUE](https://github.com/kedacore/keda/issues/ISSUE))
+
 ### New
 
 - **General**: TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -124,7 +124,7 @@ func isRemovingFinalizer(so *ScaledObject, old runtime.Object) bool {
 	soSpecString := string(soSpec)
 	oldSoSpecString := string(oldSoSpec)
 
-	return len(so.ObjectMeta.Finalizers) == 0 && len(oldSo.ObjectMeta.Finalizers) == 1 && soSpecString == oldSoSpecString
+	return len(so.ObjectMeta.Finalizers) < len(oldSo.ObjectMeta.Finalizers) && soSpecString == oldSoSpecString
 }
 
 func validateWorkload(so *ScaledObject, action string, dryRun bool) (admission.Warnings, error) {

--- a/pkg/scalers/coralogix_scaler.go
+++ b/pkg/scalers/coralogix_scaler.go
@@ -1,0 +1,95 @@
+package scalers
+
+import (
+	"fmt"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+	"reflect"
+)
+
+const (
+	scalerTypeKey           = "scalerType"
+	promScaler              = "prometheus_scaler"
+	domainNameKey           = "domain"
+	tokenKey                = "token"
+	tokenHeaderStringFmtKey = "token_header_fmt"
+	promServerAddressFmt    = "prometheusAPIStringFmt"
+
+	tokenHeaderStringFmtStringFmt = "token=%s"
+	promAPIStringFmt              = "https://prom-api.%s"
+)
+
+type CoralogixMetadata struct {
+	domain            string
+	token             string
+	scalerType        string
+	promServerAddress string
+}
+
+func NewCoralogixScaler(config *ScalerConfig) (Scaler, error) {
+	coralogixMetadata, err := parseCoralogixMetadata(config)
+	if err != nil {
+		return nil, err
+	}
+
+	scalerMap := map[string]func(*ScalerConfig, *CoralogixMetadata) (Scaler, error){
+		promScaler: NewPromScaler,
+	}
+
+	if v, ok := scalerMap[coralogixMetadata.scalerType]; ok {
+		return v(config, coralogixMetadata)
+	}
+
+	return nil, fmt.Errorf("%s must be one of the following option %s, the provided value is %s", scalerTypeKey, reflect.ValueOf(scalerMap).MapKeys(), coralogixMetadata.scalerType)
+}
+
+func OverloadPrometheusMetadata(config *ScalerConfig, coralogixMetadata *CoralogixMetadata) *ScalerConfig {
+	parsedCustomHeaders, _ := kedautil.ParseStringList(config.TriggerMetadata[promCustomHeaders])
+	if _, ok := parsedCustomHeaders[tokenKey]; !ok {
+		if val, ok := config.TriggerMetadata[promCustomHeaders]; ok && val != "" {
+			config.TriggerMetadata[promCustomHeaders] = fmt.Sprintf("%s,%s", val, coralogixMetadata.token)
+		} else {
+			config.TriggerMetadata[promCustomHeaders] = coralogixMetadata.token
+		}
+	}
+
+	config.TriggerMetadata[promServerAddress] = coralogixMetadata.promServerAddress
+	return config
+}
+
+func NewPromScaler(config *ScalerConfig, coralogixMetadata *CoralogixMetadata) (Scaler, error) {
+	return NewPrometheusScaler(OverloadPrometheusMetadata(config, coralogixMetadata))
+}
+
+func parseCoralogixMetadata(config *ScalerConfig) (meta *CoralogixMetadata, err error) {
+	domain, err := GetFromAuthOrMeta(config, domainNameKey)
+	if err != nil {
+		return nil, err
+	}
+	token, err := GetFromAuthOrMeta(config, tokenKey)
+	if err != nil {
+		return nil, err
+	}
+	scalerType, err := GetFromAuthOrMeta(config, scalerTypeKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenHeaderStringFmt, ok := config.TriggerMetadata[tokenHeaderStringFmtKey]
+	if !ok {
+		tokenHeaderStringFmt = tokenHeaderStringFmtStringFmt
+	}
+	tokenHeaderParsed := fmt.Sprintf(tokenHeaderStringFmt, token)
+
+	prometheusAPIStringFmt, ok := config.TriggerMetadata[promServerAddressFmt]
+	if !ok {
+		prometheusAPIStringFmt = promAPIStringFmt
+	}
+	prometheusServers := fmt.Sprintf(prometheusAPIStringFmt, domain)
+
+	return &CoralogixMetadata{
+		domain:            domain,
+		token:             tokenHeaderParsed,
+		scalerType:        scalerType,
+		promServerAddress: prometheusServers,
+	}, nil
+}

--- a/pkg/scalers/coralogix_scaler_test.go
+++ b/pkg/scalers/coralogix_scaler_test.go
@@ -1,0 +1,126 @@
+package scalers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type parseCoralogixMetadataTestData struct {
+	metadata    map[string]string
+	metadateRes CoralogixMetadata
+	raisesError bool
+}
+
+type overloadPrometheusConfig struct {
+	metadata          map[string]string
+	coralogixMetadata CoralogixMetadata
+	metadateRes       map[string]string
+}
+
+var testCoralogixMetadata = []parseCoralogixMetadataTestData{
+	// No metadata
+	{
+		metadata:    map[string]string{},
+		metadateRes: CoralogixMetadata{},
+		raisesError: true,
+	},
+	// Missing token
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com"},
+		metadateRes: CoralogixMetadata{},
+		raisesError: true,
+	},
+	// Missing domain
+	{
+		metadata:    map[string]string{tokenKey: "abcdefghijklmnop123123456"},
+		metadateRes: CoralogixMetadata{},
+		raisesError: true,
+	},
+	// Missing scaler type
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456"},
+		metadateRes: CoralogixMetadata{},
+		raisesError: true,
+	},
+	// Basic configurations
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query"},
+		metadateRes: CoralogixMetadata{domain: "coralogix.com", token: "token=abcdefghijklmnop123123456", scalerType: promScaler, promServerAddress: "https://prom-api.coralogix.com"},
+		raisesError: false,
+	},
+	// Custom prometheus api endpoint
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query", promServerAddressFmt: "https://blabla.%s"},
+		metadateRes: CoralogixMetadata{domain: "coralogix.com", token: "token=abcdefghijklmnop123123456", scalerType: promScaler, promServerAddress: "https://blabla.coralogix.com"},
+		raisesError: false,
+	},
+	// Custom prometheus api endpoint - missing format placeholder
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query", promServerAddressFmt: "https://blabla."},
+		metadateRes: CoralogixMetadata{},
+		raisesError: true,
+	},
+	// Custom token header formatter
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query", tokenHeaderStringFmtKey: "token_api=%s"},
+		metadateRes: CoralogixMetadata{domain: "coralogix.com", token: "token_api=abcdefghijklmnop123123456", scalerType: promScaler, promServerAddress: "https://prom-api.coralogix.com"},
+		raisesError: false,
+	},
+	// Custom token header formatter - missing format placeholder
+	{
+		metadata:    map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query", tokenHeaderStringFmtKey: "token_api:"},
+		metadateRes: CoralogixMetadata{},
+		raisesError: true,
+	},
+}
+
+var testOverloadMetadata = []overloadPrometheusConfig{
+	// Basic configurations
+	{
+		metadata:          map[string]string{domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query"},
+		coralogixMetadata: CoralogixMetadata{domain: "coralogix.com", token: "token=abcdefghijklmnop123123456", scalerType: promScaler, promServerAddress: "https://prom-api.coralogix.com"},
+		metadateRes: map[string]string{
+			domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query",
+			promCustomHeaders: "token=abcdefghijklmnop123123456", promServerAddress: "https://prom-api.coralogix.com",
+		},
+	},
+	// Append headers
+	{
+		metadata:          map[string]string{promCustomHeaders: "some_header=bla_bla", domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query"},
+		coralogixMetadata: CoralogixMetadata{domain: "coralogix.com", token: "token=abcdefghijklmnop123123456", scalerType: promScaler, promServerAddress: "https://prom-api.coralogix.com"},
+		metadateRes: map[string]string{
+			domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query",
+			promCustomHeaders: "some_header=bla_bla,token=abcdefghijklmnop123123456", promServerAddress: "https://prom-api.coralogix.com",
+		},
+	},
+	// Append headers if not exists
+	{
+		metadata:          map[string]string{promCustomHeaders: fmt.Sprintf("some_header=bla_bla,%s=some_token", tokenKey), domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query"},
+		coralogixMetadata: CoralogixMetadata{domain: "coralogix.com", token: "token=abcdefghijklmnop123123456", scalerType: promScaler, promServerAddress: "https://prom-api.coralogix.com"},
+		metadateRes: map[string]string{
+			domainNameKey: "coralogix.com", tokenKey: "abcdefghijklmnop123123456", scalerTypeKey: promScaler, "query": "some dummy query",
+			promCustomHeaders: fmt.Sprintf("some_header=bla_bla,%s=some_token", tokenKey), promServerAddress: "https://prom-api.coralogix.com",
+		},
+	},
+}
+
+func TestParseCoralogixMetadata(t *testing.T) {
+	for _, testData := range testCoralogixMetadata {
+		meta, err := parseCoralogixMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
+		if err != nil && !testData.raisesError {
+			t.Error("Expected success but got error:", err)
+		} else if !testData.raisesError && !reflect.DeepEqual(meta, &testData.metadateRes) {
+			t.Errorf("Expected parsed metadata to be equal to test values:\nParsed metadate: %+v \nTest metadata: %+v", meta, testData.metadateRes)
+		}
+	}
+}
+
+func TestOverloadPrometheusMetadata(t *testing.T) {
+	for _, testData := range testOverloadMetadata {
+		scalerConfig := OverloadPrometheusMetadata(&ScalerConfig{TriggerMetadata: testData.metadata}, &testData.coralogixMetadata)
+		if !reflect.DeepEqual(&scalerConfig.TriggerMetadata, &testData.metadateRes) {
+			t.Errorf("Expected parsed metadata to be equal to test values:\nParsed metadate: %+v \nTest metadata: %+v", scalerConfig.TriggerMetadata, testData.metadateRes)
+		}
+	}
+}

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -144,6 +144,8 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 		return scalers.NewAzureServiceBusScaler(ctx, config)
 	case "cassandra":
 		return scalers.NewCassandraScaler(config)
+	case "coralogix":
+		return scalers.NewCoralogixScaler(config)
 	case "couchdb":
 		return scalers.NewCouchDBScaler(ctx, config)
 	case "cpu":


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
As many users use Coralogix as their metrics backend, they would like to autoscale their cluster based on the metrics they have in Coralogix.
As Coralogix gateway wraps Prometheus, in the PR we are wrapping the Prometheus Scaler

Things that we would like to add in the next iteration is *Log Query* based scaler

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
